### PR TITLE
fix: Update custom scaling to make model run with AMMR 3.1.4

### DIFF
--- a/Model/ScalingCustom_muscle_insertion.any
+++ b/Model/ScalingCustom_muscle_insertion.any
@@ -5,16 +5,14 @@
 
 HumanModel.Scaling.GeometricalScaling = { 
   
-  #define CUSTOM_SCALING_Right_Scapula
   Right.Scapula= {
     #include "Scapula/ScalingLawScapula.any"
-    AnyFunTransform3D &ScaleFunction = MyScalingLaw.MyTransform;
+    ScaleFunction.Custom = &MyScalingLaw.MyTransform;
   }; 
   
-  #define CUSTOM_SCALING_Right_Humerus
   Right.Humerus= {
     #include "Humerus/ScalingLawHumerus.any"
-    AnyFunTransform3D &ScaleFunction = MyScalingLaw.MyTransform;
+    ScaleFunction.Custom = &MyScalingLaw.MyTransform;
   }; 
   
   

--- a/libdef.any
+++ b/libdef.any
@@ -1,9 +1,14 @@
-#include "C:/Anybody_projet/ammr-master/ammr-master/libdef.any"
+#ifpathexists "../libdef.any"
+#include "../libdef.any"
+#else 
+#include "<ANYBODY_PATH_INSTALLDIR>/ammr/libdef.any"
 
-#if AMMR_VERSION_MAJOR < 2 |  (AMMR_VERSION_MAJOR <= 2 & AMMR_VERSION_MINOR < 3)
+#endif
+
+#if AMMR_VERSION_MAJOR < 2 |  (AMMR_VERSION_MAJOR <= 2 & AMMR_VERSION_MINOR < 4)
 
 Main =  {
-ERROR "Wrong AMMR version. Please modify libdef.any to point to the correct AMMR (>=2.2)"
+ERROR "Wrong AMMR version. Please modify libdef.any to point to the correct AMMR (>=2.4)"
 };
 #endif
 


### PR DESCRIPTION
This PR makes the model run without deprecation warnings with AMMR 3.4.1

~@margauxpeixoto We should add a 'tag' to the version control system to indicate the version which was part of your paper.~
Edit: That will come automatically, when you make a GitHub release and create the DOI. 